### PR TITLE
Only display error debug info if available

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,9 +41,13 @@ export function renderWorkshopId(workshopId: number) {
 }
 
 export function toErrorMsg(error: any){
-  if(typeof error.response.data === 'object'){
-    return `${error.response.data.debug_info}, ${error.response.data.message}`
-  }else{
+  if (typeof error.response.data !== 'object') {
     return `${error.response.data}`
   }
+
+  if (error.response.data.debug_info) {
+    return `${error.response.data.debug_info}, ${error.response.data.message}`
+  }
+
+  return `${error.response.data.message}`
 }


### PR DESCRIPTION
When the API returns an error, it will return a `message` field, and optionally
a `debug_info` field. This `debug_info` field is only included if the API
itself is not running in production though, so the dashboard should check if it
exists.
